### PR TITLE
Add Redis Cluster support to Redis Connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>2.10.2</version>
+            <version>3.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.synapse</groupId>

--- a/src/main/java/org/wso2/carbon/connector/operations/Append.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Append.java
@@ -22,31 +22,33 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class Append extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String value = messageContext.getProperty(RedisConstants.VALUE).toString();
-                Long response = jedis.append(key, value);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String value = messageContext.getProperty(RedisConstants.VALUE).toString();
+            Long response;
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().append(key, value);
+            } else {
+                response = serverObj.getJedis().append(key, value);
+            }
+
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/BrPop.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/BrPop.java
@@ -22,7 +22,6 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 import java.util.List;
 
@@ -30,26 +29,30 @@ public class BrPop extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Integer brpopTimeout = Integer.parseInt(messageContext.getProperty(RedisConstants.BRPOPTIMEOUT).toString());
-                String[] keyValue = key.split(" ");
-                List<String> response = jedis.brpop(brpopTimeout, keyValue);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response.toString());
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            int brpopTimeout = Integer.parseInt(messageContext.getProperty(RedisConstants.BRPOPTIMEOUT).toString());
+            String[] keyValue = key.split(" ");
+            List<String> response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().brpop(brpopTimeout, keyValue);
+            } else {
+                response = serverObj.getJedis().brpop(brpopTimeout, keyValue);
+            }
+
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response.toString());
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/DecrBy.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/DecrBy.java
@@ -22,31 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class DecrBy extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Long value = Long.parseLong(messageContext.getProperty(RedisConstants.INTEGER).toString());
-                Long response = jedis.decrBy(key, value);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            long value = Long.parseLong(messageContext.getProperty(RedisConstants.INTEGER).toString());
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().decrBy(key, value);
+            } else {
+                response = serverObj.getJedis().decrBy(key, value);
+            }
+
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/Del.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Del.java
@@ -22,31 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class Del extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String[] keyValue = key.split(" ");
-                Long response = jedis.del(keyValue);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String[] keyValue = key.split(" ");
+            Long response;
+
+            serverObj = new RedisServer(messageContext);
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().del(keyValue);
+            } else {
+                response = serverObj.getJedis().del(keyValue);
+            }
+
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/Echo.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Echo.java
@@ -22,30 +22,32 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class Echo extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.MESSAGE).toString();
-                String response = jedis.echo(key);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.MESSAGE).toString();
+            String response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().echo(key);
+            } else {
+                response = serverObj.getJedis().echo(key);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/Exists.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Exists.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class Exists extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Boolean response = jedis.exists(key);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            Boolean response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().exists(key);
+            } else {
+                response = serverObj.getJedis().exists(key);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }
-    
+
 }

--- a/src/main/java/org/wso2/carbon/connector/operations/Expire.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Expire.java
@@ -22,32 +22,33 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class Expire extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Integer seconds = Integer.parseInt(messageContext.getProperty(RedisConstants.SECONDS).toString());
-                Long response = jedis.expire(key, seconds);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            int seconds = Integer.parseInt(messageContext.getProperty(RedisConstants.SECONDS).toString());
+            Long response;
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().expire(key, seconds);
+            } else {
+                response = serverObj.getJedis().expire(key, seconds);
+            }
+
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
-
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/FlushAll.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/FlushAll.java
@@ -22,29 +22,31 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class FlushAll extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String response = jedis.flushAll();
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String response = null;
+
+            if (serverObj.isClusterEnabled()) {
+                handleException("Unsupported operation \"flushAll()\" in Redis Cluster", messageContext);
+            } else {
+                response = serverObj.getJedis().flushAll();
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/FlushDB.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/FlushDB.java
@@ -22,29 +22,31 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class FlushDB extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String response = jedis.flushDB();
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String response = null;
+
+            if (serverObj.isClusterEnabled()) {
+                handleException("Unsupported operation \"fflushDB()\" in Redis Cluster", messageContext);
+            } else {
+                response = serverObj.getJedis().flushDB();
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/Get.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Get.java
@@ -22,30 +22,32 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class Get extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String response = jedis.get(key);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String response;
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().get(key);
+            } else {
+                response = serverObj.getJedis().get(key);
+            }
+
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/GetRange.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/GetRange.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class GetRange extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Long start = Long.parseLong(messageContext.getProperty(RedisConstants.START).toString());
-                Long end = Long.parseLong(messageContext.getProperty(RedisConstants.END).toString());
-                String response = jedis.getrange(key, start, end);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            long start = Long.parseLong(messageContext.getProperty(RedisConstants.START).toString());
+            long end = Long.parseLong(messageContext.getProperty(RedisConstants.END).toString());
+            String response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().getrange(key, start, end);
+            } else {
+                response = serverObj.getJedis().getrange(key, start, end);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/GetSet.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/GetSet.java
@@ -22,31 +22,33 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class GetSet extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String value = messageContext.getProperty(RedisConstants.VALUE).toString();
-                String response = jedis.getSet(key, value);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String value = messageContext.getProperty(RedisConstants.VALUE).toString();
+            String response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().getSet(key, value);
+            } else {
+                response = serverObj.getJedis().getSet(key, value);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/HExists.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HExists.java
@@ -22,31 +22,33 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class HExists extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String field = messageContext.getProperty(RedisConstants.FIELD).toString();
-                Boolean response = jedis.hexists(key, field);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String field = messageContext.getProperty(RedisConstants.FIELD).toString();
+            Boolean response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().hexists(key, field);
+            } else {
+                response = serverObj.getJedis().hexists(key, field);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/HIncrBy.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HIncrBy.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class HIncrBy extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String field = messageContext.getProperty(RedisConstants.FIELD).toString();
-                int value = Integer.parseInt(messageContext.getProperty(RedisConstants.VALUE).toString());
-                Long response = jedis.hincrBy(key, field, value);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String field = messageContext.getProperty(RedisConstants.FIELD).toString();
+            int value = Integer.parseInt(messageContext.getProperty(RedisConstants.VALUE).toString());
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().hincrBy(key, field, value);
+            } else {
+                response = serverObj.getJedis().hincrBy(key, field, value);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/HKeys.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HKeys.java
@@ -22,31 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
+
 import java.util.Set;
 
 public class HKeys extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Set<String> response = jedis.hkeys(key);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response.toString());
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            Set<String> response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().hkeys(key);
+            } else {
+                response = serverObj.getJedis().hkeys(key);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response.toString());
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/HLen.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HLen.java
@@ -22,30 +22,32 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class HLen extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Long response = jedis.hlen(key);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().hlen(key);
+            } else {
+                response = serverObj.getJedis().hlen(key);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/HMGet.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HMGet.java
@@ -22,7 +22,6 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 import java.util.List;
 
@@ -30,26 +29,29 @@ public class HMGet extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String fields = messageContext.getProperty(RedisConstants.FIELDS).toString();
-                String[] keyValue = fields.split(" ");
-                List<String> response = jedis.hmget(key, keyValue);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response.toString());
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String fields = messageContext.getProperty(RedisConstants.FIELDS).toString();
+            String[] keyValue = fields.split(" ");
+            List<String> response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().hmget(key, keyValue);
+            } else {
+                response = serverObj.getJedis().hmget(key, keyValue);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response.toString());
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/HMSet.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HMSet.java
@@ -22,39 +22,41 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
 public class HMSet extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Map<String, String> inputMap = new HashMap<String, String>();
-                String fieldsValues = messageContext.getProperty(RedisConstants.FIELDSVALUES).toString();
-                String[] keyValue = fieldsValues.split(" ");
-                for (int i = 1; i < keyValue.length; i=i+2) {
-                    inputMap.put(keyValue[i-1], keyValue[i]);
-                }
-                String response = jedis.hmset(key, inputMap);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            Map<String, String> inputMap = new HashMap<String, String>();
+            String fieldsValues = messageContext.getProperty(RedisConstants.FIELDSVALUES).toString();
+            String[] keyValue = fieldsValues.split(" ");
+            for (int i = 1; i < keyValue.length; i = i + 2) {
+                inputMap.put(keyValue[i - 1], keyValue[i]);
+            }
+            String response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().hmset(key, inputMap);
+            } else {
+                response = serverObj.getJedis().hmset(key, inputMap);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/HSet.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HSet.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class HSet extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String field = messageContext.getProperty(RedisConstants.FIELD).toString();
-                String value = messageContext.getProperty(RedisConstants.VALUE).toString();
-                Long response = jedis.hset(key, field, value);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String field = messageContext.getProperty(RedisConstants.FIELD).toString();
+            String value = messageContext.getProperty(RedisConstants.VALUE).toString();
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().hset(key, field, value);
+            } else {
+                response = serverObj.getJedis().hset(key, field, value);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/HSetnX.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HSetnX.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class HSetnX extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String field = messageContext.getProperty(RedisConstants.FIELD).toString();
-                String value = messageContext.getProperty(RedisConstants.VALUE).toString();
-                Long response = jedis.hsetnx(key, field, value);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String field = messageContext.getProperty(RedisConstants.FIELD).toString();
+            String value = messageContext.getProperty(RedisConstants.VALUE).toString();
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().hsetnx(key, field, value);
+            } else {
+                response = serverObj.getJedis().hsetnx(key, field, value);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/HVals.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HVals.java
@@ -22,7 +22,6 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 import java.util.List;
 
@@ -30,24 +29,27 @@ public class HVals extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                List<String> response = jedis.hvals(key);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response.toString());
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            List<String> response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().hvals(key);
+            } else {
+                response = serverObj.getJedis().hvals(key);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response.toString());
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/IncrBy.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/IncrBy.java
@@ -22,31 +22,33 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class IncrBy extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Long integer = Long.parseLong(messageContext.getProperty(RedisConstants.INTEGER).toString());
-                Long response = jedis.incrBy(key, integer);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            long integer = Long.parseLong(messageContext.getProperty(RedisConstants.INTEGER).toString());
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().incrBy(key, integer);
+            } else {
+                response = serverObj.getJedis().incrBy(key, integer);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/Keys.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Keys.java
@@ -22,7 +22,6 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -30,24 +29,27 @@ public class Keys extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String pattern = messageContext.getProperty(RedisConstants.PATTERN).toString();
-                Set<String> response = jedis.keys(pattern);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response.toString());
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String pattern = messageContext.getProperty(RedisConstants.PATTERN).toString();
+            Set<String> response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().keys(pattern);
+            } else {
+                response = serverObj.getJedis().keys(pattern);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response.toString());
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/LLen.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LLen.java
@@ -22,30 +22,32 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class LLen extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Long response = jedis.llen(key);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().llen(key);
+            } else {
+                response = serverObj.getJedis().llen(key);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/LPop.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LPop.java
@@ -22,30 +22,32 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class LPop extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String response = jedis.lpop(key);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().lpop(key);
+            } else {
+                response = serverObj.getJedis().lpop(key);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/LPush.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LPush.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class LPush extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String strings = messageContext.getProperty(RedisConstants.STRINGS).toString();
-                String[] keyValue = strings.split(" ");
-                Long response = jedis.lpush(key, keyValue);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String strings = messageContext.getProperty(RedisConstants.STRINGS).toString();
+            String[] keyValue = strings.split(" ");
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().lpush(key, keyValue);
+            } else {
+                response = serverObj.getJedis().lpush(key, keyValue);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/LPushX.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LPushX.java
@@ -22,31 +22,33 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class LPushX extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String string = messageContext.getProperty(RedisConstants.STRING).toString();
-                Long response = jedis.lpush(key, string);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String string = messageContext.getProperty(RedisConstants.STRING).toString();
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().lpush(key, string);
+            } else {
+                response = serverObj.getJedis().lpush(key, string);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/LRange.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LRange.java
@@ -22,7 +22,6 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 import java.util.List;
 
@@ -30,26 +29,29 @@ public class LRange extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Long start = Long.parseLong(messageContext.getProperty(RedisConstants.START).toString());
-                Long end = Long.parseLong(messageContext.getProperty(RedisConstants.END).toString());
-                List<String> response = jedis.lrange(key, start, end);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response.toString());
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            long start = Long.parseLong(messageContext.getProperty(RedisConstants.START).toString());
+            long end = Long.parseLong(messageContext.getProperty(RedisConstants.END).toString());
+            List<String> response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().lrange(key, start, end);
+            } else {
+                response = serverObj.getJedis().lrange(key, start, end);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response.toString());
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/LRem.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LRem.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class LRem extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Long count = Long.parseLong(messageContext.getProperty(RedisConstants.COUNT).toString());
-                String value = messageContext.getProperty(RedisConstants.VALUE).toString();
-                Long response = jedis.lrem(key, count, value);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            long count = Long.parseLong(messageContext.getProperty(RedisConstants.COUNT).toString());
+            String value = messageContext.getProperty(RedisConstants.VALUE).toString();
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().lrem(key, count, value);
+            } else {
+                response = serverObj.getJedis().lrem(key, count, value);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/LSet.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LSet.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class LSet extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Long index = Long.parseLong(messageContext.getProperty(RedisConstants.INDEX).toString());
-                String value = messageContext.getProperty(RedisConstants.VALUE).toString();
-                String response = jedis.lset(key, index, value);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            long index = Long.parseLong(messageContext.getProperty(RedisConstants.INDEX).toString());
+            String value = messageContext.getProperty(RedisConstants.VALUE).toString();
+            String response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().lset(key, index, value);
+            } else {
+                response = serverObj.getJedis().lset(key, index, value);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/LTrim.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LTrim.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class LTrim extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Long start = Long.parseLong(messageContext.getProperty(RedisConstants.START).toString());
-                Long end = Long.parseLong(messageContext.getProperty(RedisConstants.END).toString());
-                String response = jedis.ltrim(key, start, end);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            long start = Long.parseLong(messageContext.getProperty(RedisConstants.START).toString());
+            long end = Long.parseLong(messageContext.getProperty(RedisConstants.END).toString());
+            String response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().ltrim(key, start, end);
+            } else {
+                response = serverObj.getJedis().ltrim(key, start, end);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/MSetnX.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/MSetnX.java
@@ -22,31 +22,33 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class MSetnX extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String keysValues = messageContext.getProperty(RedisConstants.KEYSVALUES).toString();
-                String[] keyValue = keysValues.split(" ");
-                Long response = jedis.msetnx(keyValue);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String keysValues = messageContext.getProperty(RedisConstants.KEYSVALUES).toString();
+            String[] keyValue = keysValues.split(" ");
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().msetnx(keyValue);
+            } else {
+                response = serverObj.getJedis().msetnx(keyValue);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/Ping.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Ping.java
@@ -22,29 +22,32 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class Ping extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String response = jedis.ping();
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String response = null;
+
+            if (serverObj.isClusterEnabled()) {
+                handleException("Unsupported operation \"ping()\" in Redis Cluster", messageContext);
+            } else {
+                response = serverObj.getJedis().ping();
+            }
+
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/Quit.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Quit.java
@@ -22,29 +22,31 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class Quit extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String response = jedis.quit();
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String response = null;
+
+            if (serverObj.isClusterEnabled()) {
+                handleException("Unsupported operation \"quit()\" in Redis Cluster", messageContext);
+            } else {
+                response = serverObj.getJedis().quit();
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/RPush.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/RPush.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class RPush extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String strings = messageContext.getProperty(RedisConstants.STRINGS).toString();
-                String[] keyValue = strings.split(" ");
-                Long response = jedis.rpush(key, keyValue);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String strings = messageContext.getProperty(RedisConstants.STRINGS).toString();
+            String[] keyValue = strings.split(" ");
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().rpush(key, keyValue);
+            } else {
+                response = serverObj.getJedis().rpush(key, keyValue);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/RPushX.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/RPushX.java
@@ -22,31 +22,33 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class RPushX extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String value = messageContext.getProperty(RedisConstants.VALUE).toString();
-                Long response = jedis.rpushx(key, value);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String value = messageContext.getProperty(RedisConstants.VALUE).toString();
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().rpushx(key, value);
+            } else {
+                response = serverObj.getJedis().rpushx(key, value);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/RandomKey.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/RandomKey.java
@@ -22,29 +22,31 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class RandomKey extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String response = jedis.randomKey();
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String response = null;
+
+            if (serverObj.isClusterEnabled()) {
+                handleException("Unsupported operation \"randomKey()\" in Redis Cluster", messageContext);
+            } else {
+                response = serverObj.getJedis().randomKey();
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/Rename.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Rename.java
@@ -22,31 +22,33 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class Rename extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String oldKey = messageContext.getProperty(RedisConstants.OLDKEY).toString();
-                String newKey = messageContext.getProperty(RedisConstants.NEWKEY).toString();
-                String response = jedis.rename(oldKey, newKey);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String oldKey = messageContext.getProperty(RedisConstants.OLDKEY).toString();
+            String newKey = messageContext.getProperty(RedisConstants.NEWKEY).toString();
+            String response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().rename(oldKey, newKey);
+            } else {
+                response = serverObj.getJedis().rename(oldKey, newKey);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/RenamenX.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/RenamenX.java
@@ -22,31 +22,33 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class RenamenX extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String oldKey = messageContext.getProperty(RedisConstants.OLDKEY).toString();
-                String newKey = messageContext.getProperty(RedisConstants.NEWKEY).toString();
-                Long response = jedis.renamenx(oldKey, newKey);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String oldKey = messageContext.getProperty(RedisConstants.OLDKEY).toString();
+            String newKey = messageContext.getProperty(RedisConstants.NEWKEY).toString();
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().renamenx(oldKey, newKey);
+            } else {
+                response = serverObj.getJedis().renamenx(oldKey, newKey);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/SDiffStore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SDiffStore.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class SDiffStore extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String dstKey = messageContext.getProperty(RedisConstants.DSTKEY).toString();
-                String[] keyValue = key.split(" ");
-                Long response = jedis.sdiffstore(dstKey, keyValue);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String dstKey = messageContext.getProperty(RedisConstants.DSTKEY).toString();
+            String[] keyValue = key.split(" ");
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().sdiffstore(dstKey, keyValue);
+            } else {
+                response = serverObj.getJedis().sdiffstore(dstKey, keyValue);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/SInter.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SInter.java
@@ -22,7 +22,6 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -30,25 +29,28 @@ public class SInter extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String[] keyValue = key.split(" ");
-                Set<String> response = jedis.sinter(keyValue);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response.toString());
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String[] keyValue = key.split(" ");
+            Set<String> response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().sinter(keyValue);
+            } else {
+                response = serverObj.getJedis().sinter(keyValue);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response.toString());
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/SInterStore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SInterStore.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class SInterStore extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String dstKey = messageContext.getProperty(RedisConstants.DSTKEY).toString();
-                String[] keyValue = key.split(" ");
-                Long response = jedis.sinterstore(dstKey, keyValue);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String dstKey = messageContext.getProperty(RedisConstants.DSTKEY).toString();
+            String[] keyValue = key.split(" ");
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().sinterstore(dstKey, keyValue);
+            } else {
+                response = serverObj.getJedis().sinterstore(dstKey, keyValue);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/SIsMember.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SIsMember.java
@@ -22,31 +22,33 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class SIsMember extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String member = messageContext.getProperty(RedisConstants.MEMBER).toString();
-                Boolean response = jedis.sismember(key, member);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String member = messageContext.getProperty(RedisConstants.MEMBER).toString();
+            Boolean response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().sismember(key, member);
+            } else {
+                response = serverObj.getJedis().sismember(key, member);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/SMembers.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SMembers.java
@@ -22,7 +22,6 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -30,24 +29,27 @@ public class SMembers extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Set<String> response = jedis.smembers(key);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response.toString());
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            Set<String> response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().smembers(key);
+            } else {
+                response = serverObj.getJedis().smembers(key);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response.toString());
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/SMove.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SMove.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class SMove extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String srcKey = messageContext.getProperty(RedisConstants.SRCKEY).toString();
-                String dstKey = messageContext.getProperty(RedisConstants.DSTKEY).toString();
-                String member = messageContext.getProperty(RedisConstants.MEMBER).toString();
-                Long response = jedis.smove(srcKey, dstKey, member);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String srcKey = messageContext.getProperty(RedisConstants.SRCKEY).toString();
+            String dstKey = messageContext.getProperty(RedisConstants.DSTKEY).toString();
+            String member = messageContext.getProperty(RedisConstants.MEMBER).toString();
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().smove(srcKey, dstKey, member);
+            } else {
+                response = serverObj.getJedis().smove(srcKey, dstKey, member);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/SPop.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SPop.java
@@ -22,30 +22,32 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class SPop extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String response = jedis.spop(key);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().spop(key);
+            } else {
+                response = serverObj.getJedis().spop(key);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/SRandMember.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SRandMember.java
@@ -22,30 +22,32 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class SRandMember extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String response = jedis.srandmember(key);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().srandmember(key);
+            } else {
+                response = serverObj.getJedis().srandmember(key);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/SRem.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SRem.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class SRem extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String members = messageContext.getProperty(RedisConstants.MEMBERS).toString();
-                String[] keyValue = members.split(" ");
-                Long response = jedis.srem(key, keyValue);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String members = messageContext.getProperty(RedisConstants.MEMBERS).toString();
+            String[] keyValue = members.split(" ");
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().srem(key, keyValue);
+            } else {
+                response = serverObj.getJedis().srem(key, keyValue);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/SUnion.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SUnion.java
@@ -22,7 +22,6 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -30,25 +29,28 @@ public class SUnion extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String[] keyValue = key.split(" ");
-                Set<String> response = jedis.sunion(keyValue);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response.toString());
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String[] keyValue = key.split(" ");
+            Set<String> response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().sunion(keyValue);
+            } else {
+                response = serverObj.getJedis().sunion(keyValue);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response.toString());
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/SUnionStore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SUnionStore.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class SUnionStore extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String dstKey = messageContext.getProperty(RedisConstants.DSTKEY).toString();
-                String[] keyValue = key.split(" ");
-                Long response = jedis.sunionstore(dstKey, keyValue);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String dstKey = messageContext.getProperty(RedisConstants.DSTKEY).toString();
+            String[] keyValue = key.split(" ");
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().sunionstore(dstKey, keyValue);
+            } else {
+                response = serverObj.getJedis().sunionstore(dstKey, keyValue);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/Sadd.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Sadd.java
@@ -19,33 +19,38 @@
 package org.wso2.carbon.connector.operations;
 
 import org.apache.synapse.MessageContext;
-import org.apache.synapse.SynapseException;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class Sadd extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String members = messageContext.getProperty(RedisConstants.MEMBERS).toString();
-                String[] keyValue = members.split(" ");
-                Long response = jedis.sadd(key, keyValue);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String members = messageContext.getProperty(RedisConstants.MEMBERS).toString();
+            String[] keyValue = members.split(" ");
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().sadd(key, keyValue);
+            } else {
+                response = serverObj.getJedis().sadd(key, keyValue);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
-            throw new SynapseException("Error while connecting the server or calling the redis method", e);
+            handleException("Error while connecting the server or calling the redis method", e, messageContext);
+        } finally {
+            if (serverObj != null) {
+                serverObj.close();
+            }
         }
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/operations/Set.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Set.java
@@ -22,31 +22,33 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class Set extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String value = messageContext.getProperty(RedisConstants.VALUE).toString();
-                String response = jedis.set(key, value);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String value = messageContext.getProperty(RedisConstants.VALUE).toString();
+            String response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().set(key, value);
+            } else {
+                response = serverObj.getJedis().set(key, value);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/SetBit.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SetBit.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class SetBit extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Long offset = Long.parseLong(messageContext.getProperty(RedisConstants.OFFSET).toString());
-                Boolean value = Boolean.parseBoolean(messageContext.getProperty(RedisConstants.VALUE).toString());
-                Boolean response = jedis.setbit(key, offset, value);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            long offset = Long.parseLong(messageContext.getProperty(RedisConstants.OFFSET).toString());
+            boolean value = Boolean.parseBoolean(messageContext.getProperty(RedisConstants.VALUE).toString());
+            Boolean response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().setbit(key, offset, value);
+            } else {
+                response = serverObj.getJedis().setbit(key, offset, value);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/SetRange.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SetRange.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class SetRange extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Long offset = Long.parseLong(messageContext.getProperty(RedisConstants.OFFSET).toString());
-                String value = messageContext.getProperty(RedisConstants.VALUE).toString();
-                Long response = jedis.setrange(key, offset, value);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            long offset = Long.parseLong(messageContext.getProperty(RedisConstants.OFFSET).toString());
+            String value = messageContext.getProperty(RedisConstants.VALUE).toString();
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().setrange(key, offset, value);
+            } else {
+                response = serverObj.getJedis().setrange(key, offset, value);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/SetnX.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SetnX.java
@@ -22,31 +22,33 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class SetnX extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String value = messageContext.getProperty(RedisConstants.VALUE).toString();
-                Long response = jedis.setnx(key, value);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String value = messageContext.getProperty(RedisConstants.VALUE).toString();
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().setnx(key, value);
+            } else {
+                response = serverObj.getJedis().setnx(key, value);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/StrLen.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/StrLen.java
@@ -22,30 +22,32 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class StrLen extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Long response = jedis.strlen(key);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().strlen(key);
+            } else {
+                response = serverObj.getJedis().strlen(key);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/Ttl.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Ttl.java
@@ -22,30 +22,32 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class Ttl extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Long response = jedis.ttl(key);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().ttl(key);
+            } else {
+                response = serverObj.getJedis().ttl(key);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/Type.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Type.java
@@ -28,24 +28,27 @@ public class Type extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String response = jedis.type(key);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().type(key);
+            } else {
+                response = serverObj.getJedis().type(key);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/ZCount.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZCount.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class ZCount extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Double min = Double.parseDouble(messageContext.getProperty(RedisConstants.MIN).toString());
-                Double max = Double.parseDouble(messageContext.getProperty(RedisConstants.MAX).toString());
-                Long response = jedis.zcount(key, min, max);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            double min = Double.parseDouble(messageContext.getProperty(RedisConstants.MIN).toString());
+            double max = Double.parseDouble(messageContext.getProperty(RedisConstants.MAX).toString());
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().zcount(key, min, max);
+            } else {
+                response = serverObj.getJedis().zcount(key, min, max);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/ZIncrBy.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZIncrBy.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class ZIncrBy extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Double score = Double.parseDouble(messageContext.getProperty(RedisConstants.SCORE).toString());
-                String member = messageContext.getProperty(RedisConstants.MEMBER).toString();
-                Double response = jedis.zincrby(key, score, member);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            double score = Double.parseDouble(messageContext.getProperty(RedisConstants.SCORE).toString());
+            String member = messageContext.getProperty(RedisConstants.MEMBER).toString();
+            Double response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().zincrby(key, score, member);
+            } else {
+                response = serverObj.getJedis().zincrby(key, score, member);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRange.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRange.java
@@ -22,7 +22,6 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -30,26 +29,29 @@ public class ZRange extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Long start = Long.parseLong(messageContext.getProperty(RedisConstants.START).toString());
-                Long end = Long.parseLong(messageContext.getProperty(RedisConstants.END).toString());
-                Set<String> response = jedis.zrange(key, start, end);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response.toString());
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            long start = Long.parseLong(messageContext.getProperty(RedisConstants.START).toString());
+            long end = Long.parseLong(messageContext.getProperty(RedisConstants.END).toString());
+            Set<String> response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().zrange(key, start, end);
+            } else {
+                response = serverObj.getJedis().zrange(key, start, end);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response.toString());
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRangeByScore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRangeByScore.java
@@ -22,7 +22,6 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -30,26 +29,29 @@ public class ZRangeByScore extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Double min = Double.parseDouble(messageContext.getProperty(RedisConstants.MIN).toString());
-                Double max = Double.parseDouble(messageContext.getProperty(RedisConstants.MAX).toString());
-                Set<String> response = jedis.zrangeByScore(key, min, max);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response.toString());
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            double min = Double.parseDouble(messageContext.getProperty(RedisConstants.MIN).toString());
+            double max = Double.parseDouble(messageContext.getProperty(RedisConstants.MAX).toString());
+            Set<String> response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().zrangeByScore(key, min, max);
+            } else {
+                response = serverObj.getJedis().zrangeByScore(key, min, max);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response.toString());
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRank.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRank.java
@@ -22,31 +22,33 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class ZRank extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String member = messageContext.getProperty(RedisConstants.MEMBER).toString();
-                Long response = jedis.zrank(key, member);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String member = messageContext.getProperty(RedisConstants.MEMBER).toString();
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().zrank(key, member);
+            } else {
+                response = serverObj.getJedis().zrank(key, member);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRem.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRem.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class ZRem extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String members = messageContext.getProperty(RedisConstants.MEMBERS).toString();
-                String[] keyValue = members.split(" ");
-                Long response = jedis.zrem(key, keyValue);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String members = messageContext.getProperty(RedisConstants.MEMBERS).toString();
+            String[] keyValue = members.split(" ");
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().zrem(key, keyValue);
+            } else {
+                response = serverObj.getJedis().zrem(key, keyValue);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRemRangeByRank.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRemRangeByRank.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class ZRemRangeByRank extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Long start = Long.parseLong(messageContext.getProperty(RedisConstants.START).toString());
-                Long end = Long.parseLong(messageContext.getProperty(RedisConstants.END).toString());
-                Long response = jedis.zremrangeByRank(key, start, end);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            long start = Long.parseLong(messageContext.getProperty(RedisConstants.START).toString());
+            long end = Long.parseLong(messageContext.getProperty(RedisConstants.END).toString());
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().zremrangeByRank(key, start, end);
+            } else {
+                response = serverObj.getJedis().zremrangeByRank(key, start, end);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRemRangeByScore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRemRangeByScore.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class ZRemRangeByScore extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Double start = Double.parseDouble(messageContext.getProperty(RedisConstants.START).toString());
-                Double end = Double.parseDouble(messageContext.getProperty(RedisConstants.END).toString());
-                Long response = jedis.zremrangeByScore(key, start, end);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            double start = Double.parseDouble(messageContext.getProperty(RedisConstants.START).toString());
+            double end = Double.parseDouble(messageContext.getProperty(RedisConstants.END).toString());
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().zremrangeByScore(key, start, end);
+            } else {
+                response = serverObj.getJedis().zremrangeByScore(key, start, end);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRevRange.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRevRange.java
@@ -22,7 +22,6 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -30,26 +29,29 @@ public class ZRevRange extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Long start = Long.parseLong(messageContext.getProperty(RedisConstants.START).toString());
-                Long end = Long.parseLong(messageContext.getProperty(RedisConstants.END).toString());
-                Set<String> response = jedis.zrevrange(key, start, end);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response.toString());
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            long start = Long.parseLong(messageContext.getProperty(RedisConstants.START).toString());
+            long end = Long.parseLong(messageContext.getProperty(RedisConstants.END).toString());
+            Set<String> response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().zrevrange(key, start, end);
+            } else {
+                response = serverObj.getJedis().zrevrange(key, start, end);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response.toString());
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRevRangeByScore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRevRangeByScore.java
@@ -22,7 +22,6 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -30,26 +29,29 @@ public class ZRevRangeByScore extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                Double min = Double.parseDouble(messageContext.getProperty(RedisConstants.MIN).toString());
-                Double max = Double.parseDouble(messageContext.getProperty(RedisConstants.MAX).toString());
-                Set<String> response = jedis.zrevrangeByScore(key, min, max);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response.toString());
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            double min = Double.parseDouble(messageContext.getProperty(RedisConstants.MIN).toString());
+            double max = Double.parseDouble(messageContext.getProperty(RedisConstants.MAX).toString());
+            Set<String> response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().zrevrangeByScore(key, min, max);
+            } else {
+                response = serverObj.getJedis().zrevrangeByScore(key, min, max);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response.toString());
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRevRank.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRevRank.java
@@ -22,31 +22,33 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class ZRevRank extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String member = messageContext.getProperty(RedisConstants.MEMBER).toString();
-                Long response = jedis.zrevrank(key, member);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String member = messageContext.getProperty(RedisConstants.MEMBER).toString();
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().zrevrank(key, member);
+            } else {
+                response = serverObj.getJedis().zrevrank(key, member);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/ZScore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZScore.java
@@ -22,31 +22,33 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class ZScore extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String key = messageContext.getProperty(RedisConstants.KEY).toString();
-                String member = messageContext.getProperty(RedisConstants.MEMBER).toString();
-                Double response = jedis.zscore(key, member);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String key = messageContext.getProperty(RedisConstants.KEY).toString();
+            String member = messageContext.getProperty(RedisConstants.MEMBER).toString();
+            Double response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().zscore(key, member);
+            } else {
+                response = serverObj.getJedis().zscore(key, member);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/operations/ZUnionStore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZUnionStore.java
@@ -22,32 +22,34 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
-import redis.clients.jedis.Jedis;
 
 public class ZUnionStore extends AbstractConnector {
 
     @Override
     public void connect(MessageContext messageContext) throws ConnectException {
-        Jedis jedis = null;
+        RedisServer serverObj = null;
         try {
-            RedisServer serverObj = new RedisServer();
-            jedis = serverObj.connect(messageContext);
-            if (jedis != null) {
-                String dstKey = messageContext.getProperty(RedisConstants.DSTKEY).toString();
-                String sets = messageContext.getProperty(RedisConstants.SETS).toString();
-                String[] keyValue = sets.split(" ");
-                Long response = jedis.zunionstore(dstKey, keyValue);
-                if (response != null) {
-                    messageContext.setProperty(RedisConstants.RESULT, response);
-                } else {
-                    handleException("Redis server throw null response", messageContext);
-                }
+            serverObj = new RedisServer(messageContext);
+            String dstKey = messageContext.getProperty(RedisConstants.DSTKEY).toString();
+            String sets = messageContext.getProperty(RedisConstants.SETS).toString();
+            String[] keyValue = sets.split(" ");
+            Long response;
+
+            if (serverObj.isClusterEnabled()) {
+                response = serverObj.getJedisCluster().zunionstore(dstKey, keyValue);
+            } else {
+                response = serverObj.getJedis().zunionstore(dstKey, keyValue);
+            }
+            if (response != null) {
+                messageContext.setProperty(RedisConstants.RESULT, response);
+            } else {
+                handleException("Redis server throw null response", messageContext);
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);
         } finally {
-            if (jedis != null) {
-                jedis.disconnect();
+            if (serverObj != null) {
+                serverObj.close();
             }
         }
     }

--- a/src/main/java/org/wso2/carbon/connector/util/RedisConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/util/RedisConstants.java
@@ -59,4 +59,14 @@ public class RedisConstants {
     public static final String CACHEKEY = "cacheKey";
     public static final String CACHEHOSTNAME = "cacheHostname";
     public static final String USESSL = "useSsl";
+    public static final String CONNECTION_TIMEOUT = "redisConnectionTimeout";
+    public static final String REDIS_CLUSTER_ENABLED = "redisClusterEnabled";
+    public static final String CLUSTER_NODES = "clusterNodes";
+    public static final String CLIENT_NAME = "clientName";
+    public static final String MAX_ATTEMPTS = "maxAttempts";
+    public static final String WEIGHT = "weight";
+
+    public static final int DEFAULT_TIMEOUT = 2000;
+    public static final int DEFAULT_MAX_ATTEMPTS = 5;
+    public static final int DEFAULT_WEIGHT = 1;
 }

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -18,22 +18,33 @@
 -->
 
 <template name="init" xmlns="http://ws.apache.org/ns/synapse">
-    <parameter name="redisHost" description="the server host"/>
-    <parameter name="redisPort" description="the port to server run"/>
+    <parameter name="redisConnectionTimeout" description="time to live the connection in milliseconds"/>
     <parameter name="redisTimeout" description="time to live the server in milliseconds"/>
     <parameter name="cacheKey" description="key of the cache"/>
     <parameter name="useSsl" description="a flag to switch between SSL and non-SSL"/>
+
+    <!-- standalone mode specific parameters-->
+    <parameter name="redisHost" description="the server host"/>
+    <parameter name="redisPort" description="the port to server run"/>
+    <parameter name="weight" description="weight of the shard"/>
+
+    <!-- cluster specific parameters -->
+    <parameter name="redisClusterEnabled" description="a flag to enable cluster mode"/>
+    <parameter name="clusterNodes" description="comma separated list of the cluster nodes (host:port)"/>
+    <parameter name="clientName" description="name of the client"/>
+    <parameter name="maxAttempts" description="the number of retries"/>
+
     <sequence>
         <filter xpath="$func:redisPort = '' or  not(string($func:redisPort))">
             <then/>
             <else>
-                <property name="redisPort" expression="$ctx:redisPort"/>
+                <property name="redisPort" expression="$func:redisPort"/>
             </else>
         </filter>
         <filter xpath="$func:redisTimeout = '' or  not(string($func:redisTimeout))">
             <then/>
             <else>
-                <property name="redisTimeout" expression="$ctx:redisTimeout"/>
+                <property name="redisTimeout" expression="$func:redisTimeout"/>
             </else>
         </filter>
         <property name="redisHost" expression="$func:redisHost"/>
@@ -45,13 +56,49 @@
         <filter xpath="$func:cacheKey = '' or  not(string($func:cacheKey))">
             <then/>
             <else>
-                <property name="cacheKey" expression="$ctx:cacheKey"/>
+                <property name="cacheKey" expression="$func:cacheKey"/>
             </else>
         </filter>
         <filter xpath="$func:useSsl = '' or  not(string($func:useSsl))">
             <then/>
             <else>
-                <property name="useSsl" expression="$ctx:useSsl"/>
+                <property name="useSsl" expression="$func:useSsl"/>
+            </else>
+        </filter>
+        <filter xpath="$func:redisConnectionTimeout = '' or  not(string($func:redisConnectionTimeout))">
+            <then/>
+            <else>
+                <property name="redisConnectionTimeout" expression="$func:redisConnectionTimeout"/>
+            </else>
+        </filter>
+        <filter xpath="$func:redisClusterEnabled = '' or  not(string($func:redisClusterEnabled))">
+            <then/>
+            <else>
+                <property name="redisClusterEnabled" expression="$func:redisClusterEnabled"/>
+            </else>
+        </filter>
+        <filter xpath="$func:clusterNodes = '' or  not(string($func:clusterNodes))">
+            <then/>
+            <else>
+                <property name="clusterNodes" expression="$func:clusterNodes"/>
+            </else>
+        </filter>
+        <filter xpath="$func:clientName = '' or  not(string($func:clientName))">
+            <then/>
+            <else>
+                <property name="clientName" expression="$func:clientName"/>
+            </else>
+        </filter>
+        <filter xpath="$func:maxAttempts = '' or  not(string($func:maxAttempts))">
+            <then/>
+            <else>
+                <property name="maxAttempts" expression="$func:maxAttempts"/>
+            </else>
+        </filter>
+        <filter xpath="$func:weight = '' or  not(string($func:weight))">
+            <then/>
+            <else>
+                <property name="weight" expression="$func:weight"/>
             </else>
         </filter>
     </sequence>


### PR DESCRIPTION
## Purpose

With this PR, the Redis Connector supports both standalone and cluster modes with the exact same syntax and operation names except the following operations, which are deprecated in Redis cluster mode.  

```
redis.clients.jedis.BinaryJedisCluster.flushAll()
redis.clients.jedis.BinaryJedisCluster.flushDB()
redis.clients.jedis.BinaryJedisCluster.ping()
redis.clients.jedis.BinaryJedisCluster.quit()
redis.clients.jedis.BinaryJedisCluster.randomKey()
```

The init operation for both standalone and cluster slightly differs from each other and the format is as follows.
```
<!-- Cluster mode specific initialization parameters -->
<redis.init>
    <!-- A flag to enable the redis cluster mode. Required parameter -->
    <redisClusterEnabled>true</redisClusterEnabled>   
    <!-- Comma separated list of the cluster nodes as Node1_hostname:Port,Node2_hostname:Port.. Required parameter -->              
    <clusterNodes>127.0.0.1:40001,127.0.0.1:40002</clusterNodes>    
    <!-- Time to live the server in millis. Optional parameter -->
    <redisTimeout>60000</redisTimeout>             
    <!-- The number of retries. Optional parameter -->       
    <maxAttempts>5</maxAttempts>          
     <!-- Key of the cache (password). Optional parameter -->                          
    <cacheKey>key</cacheKey>
    <!-- A flag to switch between SSL and non-SSL. Optional parameter. Default is false -->                                       
    <useSsl>true</useSsl>    
    <!-- Name of the client. Optional parameter -->                                       
    <clientName>WSO2EI</clientName>                                 
</redis.init>


<!-- Standalone mode specific initialization parameters -->
<redis.init>
    <!-- A flag to enable the redis cluster mode. Optional parameter -->
    <redisClusterEnabled>false</redisClusterEnabled>  
    <!-- The server host. Required parameter -->              
    <redisHost>127.0.0.1</redisHost>
    <!-- The port to run the server. Optional parameter -->                                
    <redisPort>40001</redisPort>          
    <!-- Time to live the server in millis. Optional parameter -->                          
    <redisTimeout>60000</redisTimeout>   
    <!-- Time to live the connection in millis. Optional parameter -->                    
    <redisConnectionTimeout>60000</redisConnectionTimeout>
    <!-- Key of the cache (password). Optional parameter -->                           
    <cacheKey>key</cacheKey>         
    <!-- A flag to switch between SSL and non-SSL. Optional parameter. Default is false -->                               
    <useSsl>true</useSsl>                                           
</redis.init>
```
Please note that to use the *jedis-3.3.0.jar* for the above modifications to be effective in the server without any issues.