### PR TITLE
Introduce connectionURI property to add support to choose databases when using ShardedJedis

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/operations/RedisServer.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/RedisServer.java
@@ -27,6 +27,8 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisShardInfo;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashSet;
 import java.util.Objects;
 
@@ -90,6 +92,17 @@ public class RedisServer {
      * @return Jedis instance
      */
     private Jedis createJedis() {
+        String connectionURIProp = (String) messageContext.getProperty(RedisConstants.CONNECTION_URI);
+        if (connectionURIProp != null) {
+            try {
+                URI connectionURI = new URI(connectionURIProp);
+                return new Jedis(new JedisShardInfo(connectionURI));
+            } catch (URISyntaxException e) {
+                throw new SynapseException(
+                        "Invalid input for \"redisConnectionURI\". Please provide a URI with valid syntax", e);
+            }
+        }
+
         String host = messageContext.getProperty(RedisConstants.HOST).toString();
         int port;
         int weight = RedisConstants.DEFAULT_WEIGHT;

--- a/src/main/java/org/wso2/carbon/connector/operations/RedisServer.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/RedisServer.java
@@ -96,7 +96,10 @@ public class RedisServer {
         if (connectionURIProp != null) {
             try {
                 URI connectionURI = new URI(connectionURIProp);
-                return new Jedis(new JedisShardInfo(connectionURI));
+                JedisShardInfo shardInfo = new JedisShardInfo(connectionURI);
+                shardInfo.setSoTimeout(timeout);
+                shardInfo.setConnectionTimeout(connectionTimeout);
+                return new Jedis(shardInfo);
             } catch (URISyntaxException e) {
                 throw new SynapseException(
                         "Invalid input for \"redisConnectionURI\". Please provide a URI with valid syntax", e);

--- a/src/main/java/org/wso2/carbon/connector/util/RedisConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/util/RedisConstants.java
@@ -22,6 +22,7 @@ public class RedisConstants {
     public static final String PORT = "redisPort";
     public static final String TIMEOUT = "redisTimeout";
     public static final String HOST = "redisHost";
+    public static final String CONNECTION_URI = "redisConnectionURI";
     public static final String RESULT = "result";
     public static final String KEY = "redisKey";
     public static final String VALUE = "redisValue";

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -27,6 +27,7 @@
     <parameter name="redisHost" description="the server host"/>
     <parameter name="redisPort" description="the port to server run"/>
     <parameter name="weight" description="weight of the shard"/>
+    <parameter name="redisConnectionURI" description="redis connection URI"/>
 
     <!-- cluster specific parameters -->
     <parameter name="redisClusterEnabled" description="a flag to enable cluster mode"/>
@@ -99,6 +100,12 @@
             <then/>
             <else>
                 <property name="weight" expression="$func:weight"/>
+            </else>
+        </filter>
+        <filter xpath="$func:redisConnectionURI = '' or not(string($func:redisConnectionURI))">
+            <then/>
+            <else>
+                <property name="redisConnectionURI" expression="$func:redisConnectionURI"/>
             </else>
         </filter>
     </sequence>


### PR DESCRIPTION
## Purpose
With this PR, the Redis connector supports connection URI (in the format of `redis://[:password@]host[:port]/[database]`) to choose databases when using sharded Redis. 

Thus, the format for the init operation in standalone is as follows.

```
<!-- Standalone mode specific initialization parameters -->
<redis.init>
    <!-- A flag to enable the redis cluster mode. Optional parameter -->
    <redisClusterEnabled>false</redisClusterEnabled>  

    <!-- The server host. Required parameter -->              
    <redisHost>127.0.0.1</redisHost>

    <!-- The port to run the server. Optional parameter. Default is  6379-->                                
    <redisPort>6379</redisPort>          

    <!-- Time to live the server in millis. Optional parameter. Default is 2000ms -->                          
    <redisTimeout>60000</redisTimeout>   

    <!-- Time to live the connection in millis. Optional parameter. Default is 2000ms-->                    
    <redisConnectionTimeout>60000</redisConnectionTimeout>

    <!-- Key of the cache (password). Optional parameter -->                           
    <cacheKey>key</cacheKey>    
     
    <!-- A flag to switch between SSL and non-SSL. Optional parameter. Default is false -->                               
    <useSsl>true</useSsl>                                           
</redis.init>
```
or
```
<redis.init>
    <!-- A flag to enable the redis cluster mode. Optional parameter -->
    <redisClusterEnabled>false</redisClusterEnabled>  

    <!-- The server host. Required parameter -->              
    <redisConnectionURI>redis://127.0.0.1:6379/2</redisConnectionURI>                                           
</redis.init>
```

## Samples
### Sample 1
```
<redis.init>           
    <redisConnectionURI>redis://127.0.0.1:6379/2</redisConnectionURI>                                           
</redis.init>
```
### Sample 2
```
<redis.init>               
    <redisHost>127.0.0.1</redisHost>                           
    <redisPort>6379</redisPort>        <!-- optional -->                  
    <redisTimeout>60000</redisTimeout>        <!-- optional -->                          
    <redisConnectionTimeout>60000</redisConnectionTimeout>        <!-- optional -->                                 
    <cacheKey>key</cacheKey>        <!-- optional -->                                                  
    <useSsl>true</useSsl>        <!-- optional -->                                                  
</redis.init>
```

