### PR TITLE
Add Redis Sentinel Implementation

### DIFF
--- a/docs/configuringRedisOperations.md
+++ b/docs/configuringRedisOperations.md
@@ -48,6 +48,16 @@ If you prefer to use the connectionURI over above configuration, use the followi
 </redis.init>
 ```
 
+**Redis Sentinel**
+```xml
+ <redis.init>
+    <sentinelEnabled>true</sentinelEnabled>
+    <masterName>{$ctx:masterName}</masterName>
+    <sentinels>{$ctx:sentinels}</sentinels>
+    <masterPassword>{$ctx:masterPassword}</masterPassword>
+    <dbNumber>{$ctx:dbNumber}</dbNumber>
+</redis.init>
+```
 **Properties** 
 * redisClusterEnabled: A flag to enable the redis cluster mode (Default is false).
 * clusterNodes: Comma separated list of the cluster nodes as Node1_hostname:Port,Node2_hostname:Port, etc.
@@ -61,7 +71,11 @@ If you prefer to use the connectionURI over above configuration, use the followi
 * maxAttempts: The number of retries.
 * redisConnectionURI: The Redis connection URI in the form of `redis://[user:password@]host[:port]/[database]` or 
   `rediss://[user:password@]host[:port]/[database]` to connect over TLS/SSL
-
+* sentinelEnabled: A flag to enable sentinel
+* masterName: Master name in sentinel mode
+* sentinels: Comma separated list of sentinels
+* masterPassword: Master password (don't specify if there's no password for master)
+* dbNumber: Number of the DB (integer)
 
 Now that you have connected to Redis, use the information in the following topics to perform various operations with the connector:
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.redis</artifactId>
     <packaging>jar</packaging>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <name>WSO2 Carbon - Mediation Library Connector For Redis</name>
     <url>http://wso2.org</url>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.redis</artifactId>
     <packaging>jar</packaging>
-    <version>2.2.0</version>
+    <version>2.2.1-SNAPSHOT</version>
     <name>WSO2 Carbon - Mediation Library Connector For Redis</name>
     <url>http://wso2.org</url>
     <properties>

--- a/src/main/java/org/wso2/carbon/connector/util/RedisConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/util/RedisConstants.java
@@ -70,4 +70,10 @@ public class RedisConstants {
     public static final int DEFAULT_TIMEOUT = 2000;
     public static final int DEFAULT_MAX_ATTEMPTS = 5;
     public static final int DEFAULT_WEIGHT = 1;
+    
+     public static final String SENTINEL_ENABLED = "sentinelEnabled";
+     public static final String MASTER_NAME = "masterName";
+     public static final String SENTINELS = "sentinels";
+     public static final String MASTER_PASSWORD = "masterPassword";
+     public static final String SENTINEL_PASSWORD ="sentinelPassword";
 }

--- a/src/main/java/org/wso2/carbon/connector/util/RedisConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/util/RedisConstants.java
@@ -75,5 +75,5 @@ public class RedisConstants {
      public static final String MASTER_NAME = "masterName";
      public static final String SENTINELS = "sentinels";
      public static final String MASTER_PASSWORD = "masterPassword";
-     public static final String SENTINEL_PASSWORD ="sentinelPassword";
+     public static final String DB_NUMBER = "dbNumber";
 }

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -40,7 +40,7 @@
     <parameter name="masterName" description="master name for sentinel"/>
     <parameter name="sentinels" description="comma separated list of sentinels"/>
     <parameter name="masterPassword" description="master password"/>
-    <parameter name="sentinelPassword" description="sentinelPassword"/>
+    <parameter name="dbNumber" description="dbNumber"/>
 
     <sequence>
         <filter xpath="$func:redisPort = '' or  not(string($func:redisPort))">
@@ -139,10 +139,10 @@
                 <property name="masterPassword" expression="$func:masterPassword"/>
             </else>
         </filter>       
-        <filter xpath="$func:sentinelPassword = '' or not(string($func:sentinelPassword))">
+        <filter xpath="$func:dbNumber = '' or not(string($func:dbNumber))">
             <then/>
             <else>
-                <property name="sentinelPassword" expression="$func:sentinelPassword"/>
+                <property name="dbNumber" expression="$func:dbNumber"/>
             </else>
         </filter>
     </sequence>

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -34,6 +34,13 @@
     <parameter name="clusterNodes" description="comma separated list of the cluster nodes (host:port)"/>
     <parameter name="clientName" description="name of the client"/>
     <parameter name="maxAttempts" description="the number of retries"/>
+    
+    <!-- Redis Sentinel specific parameters-->
+    <parameter name="sentinelEnabled" description="a flag to enable redis sentinel"/>
+    <parameter name="masterName" description="master name for sentinel"/>
+    <parameter name="sentinels" description="comma separated list of sentinels"/>
+    <parameter name="masterPassword" description="master password"/>
+    <parameter name="sentinelPassword" description="sentinelPassword"/>
 
     <sequence>
         <filter xpath="$func:redisPort = '' or  not(string($func:redisPort))">
@@ -106,6 +113,36 @@
             <then/>
             <else>
                 <property name="redisConnectionURI" expression="$func:redisConnectionURI"/>
+            </else>
+        </filter>        
+        <filter xpath="$func:sentinelEnabled = '' or not(string($func:sentinelEnabled))">
+            <then/>
+            <else>
+                <property name="sentinelEnabled" expression="$func:sentinelEnabled"/>
+            </else>
+        </filter>        
+        <filter xpath="$func:masterName = '' or not(string($func:masterName))">
+            <then/>
+            <else>
+                <property name="masterName" expression="$func:masterName"/>
+            </else>
+        </filter>        
+        <filter xpath="$func:sentinels = '' or not(string($func:sentinels))">
+            <then/>
+            <else>
+                <property name="sentinels" expression="$func:sentinels"/>
+            </else>
+        </filter>        
+        <filter xpath="$func:masterPassword = '' or not(string($func:masterPassword))">
+            <then/>
+            <else>
+                <property name="masterPassword" expression="$func:masterPassword"/>
+            </else>
+        </filter>       
+        <filter xpath="$func:sentinelPassword = '' or not(string($func:sentinelPassword))">
+            <then/>
+            <else>
+                <property name="sentinelPassword" expression="$func:sentinelPassword"/>
             </else>
         </filter>
     </sequence>

--- a/src/main/resources/strings/get.xml
+++ b/src/main/resources/strings/get.xml
@@ -30,7 +30,7 @@
                 }
             </format>
             <args>
-                <arg evaluator="xml" expression="$ctx:redisResponse"/>
+                <arg evaluator="xml" expression="$ctx:redisResponse" literal="true"/>
             </args>
         </payloadFactory>
     </sequence>


### PR DESCRIPTION
## Purpose

### Adding Redis Sentinel support to Redis connector
With this implementation, Redis Sentinel can be configured using following configuration,
```xml
 <redis.init>
    <sentinelEnabled>true</sentinelEnabled>
    <masterName>{$ctx:masterName}</masterName>
    <sentinels>{$ctx:sentinels}</sentinels>
    <masterPassword>{$ctx:masterPassword}</masterPassword>
    <dbNumber>{$ctx:dbNumber}</dbNumber>
</redis.init>
```

### Changing the output of the Get operation
Previously the output of the get operation produces malformed JSON and XML outputs. This issue was fixed by providing the string presentation of the stored values in the Redis DB. Since Redis stores the values as strings this is logical and this is backward compatible since we haven't changed the output message format.

Fixes: https://github.com/wso2-extensions/esb-connector-redis/issues/33 https://github.com/wso2-extensions/esb-connector-redis/issues/32

