### PR TITLE
Fix creating connections for each request

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/operations/Append.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Append.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class Append extends AbstractConnector {
 
@@ -36,7 +37,15 @@ public class Append extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().append(key, value);
             } else {
-                response = serverObj.getJedis().append(key, value);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.append(key, value);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
 
             if (response != null) {

--- a/src/main/java/org/wso2/carbon/connector/operations/BlPop.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/BlPop.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 import java.util.List;
 
@@ -41,7 +42,16 @@ public class BlPop extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().blpop(blPopTimeout, keyValue);
             } else {
-                response = serverObj.getJedis().blpop(blPopTimeout, keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.blpop(blPopTimeout, keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
+
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response.toString());

--- a/src/main/java/org/wso2/carbon/connector/operations/BrPop.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/BrPop.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 import java.util.List;
 
@@ -40,7 +41,15 @@ public class BrPop extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().brpop(brpopTimeout, keyValue);
             } else {
-                response = serverObj.getJedis().brpop(brpopTimeout, keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.brpop(brpopTimeout, keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
 
             if (response != null) {

--- a/src/main/java/org/wso2/carbon/connector/operations/DecrBy.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/DecrBy.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class DecrBy extends AbstractConnector {
 
@@ -37,7 +38,15 @@ public class DecrBy extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().decrBy(key, value);
             } else {
-                response = serverObj.getJedis().decrBy(key, value);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.decrBy(key, value);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
 
             if (response != null) {

--- a/src/main/java/org/wso2/carbon/connector/operations/Del.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Del.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class Del extends AbstractConnector {
 
@@ -37,7 +38,15 @@ public class Del extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().del(keyValue);
             } else {
-                response = serverObj.getJedis().del(keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.del(keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
 
             if (response != null) {

--- a/src/main/java/org/wso2/carbon/connector/operations/Echo.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Echo.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class Echo extends AbstractConnector {
 
@@ -36,7 +37,15 @@ public class Echo extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().echo(key);
             } else {
-                response = serverObj.getJedis().echo(key);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.echo(key);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/Exists.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Exists.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class Exists extends AbstractConnector {
 
@@ -36,7 +37,15 @@ public class Exists extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().exists(key);
             } else {
-                response = serverObj.getJedis().exists(key);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.exists(key);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/Expire.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Expire.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class Expire extends AbstractConnector {
 
@@ -36,7 +37,15 @@ public class Expire extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().expire(key, seconds);
             } else {
-                response = serverObj.getJedis().expire(key, seconds);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.expire(key, seconds);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
 
             if (response != null) {

--- a/src/main/java/org/wso2/carbon/connector/operations/ExpireAt.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ExpireAt.java
@@ -37,7 +37,15 @@ public class ExpireAt extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().expireAt(key, unixTime);
             } else {
-                response = serverObj.getJedis().expireAt(key, unixTime);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.expireAt(key, unixTime);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
 
             if (response != null) {

--- a/src/main/java/org/wso2/carbon/connector/operations/FlushAll.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/FlushAll.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class FlushAll extends AbstractConnector {
 
@@ -35,7 +36,15 @@ public class FlushAll extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 handleException("Unsupported operation \"flushAll()\" in Redis Cluster", messageContext);
             } else {
-                response = serverObj.getJedis().flushAll();
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.flushAll();
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/FlushDB.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/FlushDB.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class FlushDB extends AbstractConnector {
 
@@ -35,7 +36,16 @@ public class FlushDB extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 handleException("Unsupported operation \"fflushDB()\" in Redis Cluster", messageContext);
             } else {
-                response = serverObj.getJedis().flushDB();
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.flushDB();
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
+
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/Get.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Get.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class Get extends AbstractConnector {
 
@@ -35,7 +36,15 @@ public class Get extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().get(key);
             } else {
-                response = serverObj.getJedis().get(key);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.get(key);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
 
             if (response != null) {

--- a/src/main/java/org/wso2/carbon/connector/operations/GetRange.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/GetRange.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class GetRange extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class GetRange extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().getrange(key, start, end);
             } else {
-                response = serverObj.getJedis().getrange(key, start, end);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.getrange(key, start, end);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/GetSet.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/GetSet.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class GetSet extends AbstractConnector {
 
@@ -37,7 +38,15 @@ public class GetSet extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().getSet(key, value);
             } else {
-                response = serverObj.getJedis().getSet(key, value);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.getSet(key, value);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/HDel.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HDel.java
@@ -23,6 +23,7 @@ import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.Constants;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class HDel extends AbstractConnector {
 
@@ -39,7 +40,15 @@ public class HDel extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().hdel(key, keyValue);
             } else {
-                response = serverObj.getJedis().hdel(key, keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.hdel(key, keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/HExists.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HExists.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class HExists extends AbstractConnector {
 
@@ -37,7 +38,15 @@ public class HExists extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().hexists(key, field);
             } else {
-                response = serverObj.getJedis().hexists(key, field);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.hexists(key, field);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/HGet.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HGet.java
@@ -40,7 +40,15 @@ public class HGet extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().hget(key, field);
             } else {
-                response = serverObj.getJedis().hget(key, field);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.hget(key, field);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/HGetAll.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HGetAll.java
@@ -39,7 +39,15 @@ public class HGetAll extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().hgetAll(key);
             } else {
-                response = serverObj.getJedis().hgetAll(key);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.hgetAll(key);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response.toString());

--- a/src/main/java/org/wso2/carbon/connector/operations/HIncrBy.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HIncrBy.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class HIncrBy extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class HIncrBy extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().hincrBy(key, field, value);
             } else {
-                response = serverObj.getJedis().hincrBy(key, field, value);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.hincrBy(key, field, value);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/HKeys.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HKeys.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -38,7 +39,15 @@ public class HKeys extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().hkeys(key);
             } else {
-                response = serverObj.getJedis().hkeys(key);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.hkeys(key);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response.toString());

--- a/src/main/java/org/wso2/carbon/connector/operations/HLen.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HLen.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class HLen extends AbstractConnector {
 
@@ -36,7 +37,15 @@ public class HLen extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().hlen(key);
             } else {
-                response = serverObj.getJedis().hlen(key);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.hlen(key);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/HMGet.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HMGet.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 import java.util.List;
 
@@ -40,7 +41,15 @@ public class HMGet extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().hmget(key, keyValue);
             } else {
-                response = serverObj.getJedis().hmget(key, keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.hmget(key, keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response.toString());

--- a/src/main/java/org/wso2/carbon/connector/operations/HMSet.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HMSet.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -45,7 +46,15 @@ public class HMSet extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().hmset(key, inputMap);
             } else {
-                response = serverObj.getJedis().hmset(key, inputMap);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.hmset(key, inputMap);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/HSet.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HSet.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class HSet extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class HSet extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().hset(key, field, value);
             } else {
-                response = serverObj.getJedis().hset(key, field, value);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.hset(key, field, value);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/HSetnX.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HSetnX.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class HSetnX extends AbstractConnector {
 
@@ -38,7 +39,16 @@ public class HSetnX extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().hsetnx(key, field, value);
             } else {
-                response = serverObj.getJedis().hsetnx(key, field, value);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.hsetnx(key, field, value);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
+
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/HVals.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/HVals.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 import java.util.List;
 
@@ -38,7 +39,15 @@ public class HVals extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().hvals(key);
             } else {
-                response = serverObj.getJedis().hvals(key);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.hvals(key);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response.toString());

--- a/src/main/java/org/wso2/carbon/connector/operations/IncrBy.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/IncrBy.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class IncrBy extends AbstractConnector {
 
@@ -37,7 +38,15 @@ public class IncrBy extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().incrBy(key, integer);
             } else {
-                response = serverObj.getJedis().incrBy(key, integer);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.incrBy(key, integer);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/Keys.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Keys.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -38,7 +39,16 @@ public class Keys extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().keys(pattern);
             } else {
-                response = serverObj.getJedis().keys(pattern);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.keys(pattern);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
+
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response.toString());

--- a/src/main/java/org/wso2/carbon/connector/operations/LInsert.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LInsert.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 import redis.clients.jedis.ListPosition;
 
 public class LInsert extends AbstractConnector {
@@ -40,7 +41,15 @@ public class LInsert extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().linsert(key, where, pivot, value);
             } else {
-                response = serverObj.getJedis().linsert(key, where, pivot, value);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.linsert(key, where, pivot, value);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/LLen.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LLen.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class LLen extends AbstractConnector {
 
@@ -36,7 +37,16 @@ public class LLen extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().llen(key);
             } else {
-                response = serverObj.getJedis().llen(key);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.llen(key);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
+
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/LPop.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LPop.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class LPop extends AbstractConnector {
 
@@ -36,7 +37,16 @@ public class LPop extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().lpop(key);
             } else {
-                response = serverObj.getJedis().lpop(key);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.lpop(key);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
+
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/LPush.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LPush.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class LPush extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class LPush extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().lpush(key, keyValue);
             } else {
-                response = serverObj.getJedis().lpush(key, keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.lpush(key, keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/LPushX.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LPushX.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class LPushX extends AbstractConnector {
 
@@ -37,7 +38,15 @@ public class LPushX extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().lpush(key, string);
             } else {
-                response = serverObj.getJedis().lpush(key, string);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.lpush(key, string);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/LRange.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LRange.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 import java.util.List;
 
@@ -40,7 +41,15 @@ public class LRange extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().lrange(key, start, end);
             } else {
-                response = serverObj.getJedis().lrange(key, start, end);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.lrange(key, start, end);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response.toString());

--- a/src/main/java/org/wso2/carbon/connector/operations/LRem.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LRem.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class LRem extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class LRem extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().lrem(key, count, value);
             } else {
-                response = serverObj.getJedis().lrem(key, count, value);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.lrem(key, count, value);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/LSet.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LSet.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class LSet extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class LSet extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().lset(key, index, value);
             } else {
-                response = serverObj.getJedis().lset(key, index, value);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.lset(key, index, value);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/LTrim.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/LTrim.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class LTrim extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class LTrim extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().ltrim(key, start, end);
             } else {
-                response = serverObj.getJedis().ltrim(key, start, end);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.ltrim(key, start, end);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/MGet.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/MGet.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 import java.util.List;
 
@@ -39,7 +40,15 @@ public class MGet extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().mget(keyValue);
             } else {
-                response = serverObj.getJedis().mget(keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.mget(keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response.toString());

--- a/src/main/java/org/wso2/carbon/connector/operations/MSet.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/MSet.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class MSet extends AbstractConnector {
 
@@ -37,7 +38,15 @@ public class MSet extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().mset(keyValue);
             } else {
-                response = serverObj.getJedis().mset(keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.mset(keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/MSetnX.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/MSetnX.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class MSetnX extends AbstractConnector {
 
@@ -37,7 +38,16 @@ public class MSetnX extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().msetnx(keyValue);
             } else {
-                response = serverObj.getJedis().msetnx(keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.msetnx(keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
+
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/Ping.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Ping.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class Ping extends AbstractConnector {
 
@@ -35,7 +36,15 @@ public class Ping extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 handleException("Unsupported operation \"ping()\" in Redis Cluster", messageContext);
             } else {
-                response = serverObj.getJedis().ping();
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.ping();
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
 
             if (response != null) {

--- a/src/main/java/org/wso2/carbon/connector/operations/Quit.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Quit.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class Quit extends AbstractConnector {
 
@@ -35,7 +36,16 @@ public class Quit extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 handleException("Unsupported operation \"quit()\" in Redis Cluster", messageContext);
             } else {
-                response = serverObj.getJedis().quit();
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.quit();
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
+
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/RPopLPush.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/RPopLPush.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class RPopLPush extends AbstractConnector {
 
@@ -37,7 +38,15 @@ public class RPopLPush extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().rpoplpush(srcKey, dstKey);
             } else {
-                response = serverObj.getJedis().rpoplpush(srcKey, dstKey);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.rpoplpush(srcKey, dstKey);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/RPush.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/RPush.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class RPush extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class RPush extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().rpush(key, keyValue);
             } else {
-                response = serverObj.getJedis().rpush(key, keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.rpush(key, keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/RPushX.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/RPushX.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class RPushX extends AbstractConnector {
 
@@ -37,7 +38,16 @@ public class RPushX extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().rpushx(key, value);
             } else {
-                response = serverObj.getJedis().rpushx(key, value);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.rpushx(key, value);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
+
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/RandomKey.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/RandomKey.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class RandomKey extends AbstractConnector {
 
@@ -35,7 +36,15 @@ public class RandomKey extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 handleException("Unsupported operation \"randomKey()\" in Redis Cluster", messageContext);
             } else {
-                response = serverObj.getJedis().randomKey();
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.randomKey();
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/RedisServer.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/RedisServer.java
@@ -25,6 +25,8 @@ import org.wso2.carbon.connector.util.RedisConstants;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.JedisSentinelPool;
 import redis.clients.jedis.JedisShardInfo;
 
@@ -33,17 +35,21 @@ import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static redis.clients.jedis.Protocol.DEFAULT_DATABASE;
 
 public class RedisServer {
 
-    private Jedis jedis;
+    private static JedisPool jedisPool = null;
+    private static JedisSentinelPool jedisSentinelPool = null;
+    private int maxConnections;
     private JedisCluster jedisCluster;
 
     private MessageContext messageContext;
     private Boolean isClusterEnabled = false;
-    private int timeout = RedisConstants.DEFAULT_TIMEOUT;
+    private int soTimeout = RedisConstants.DEFAULT_TIMEOUT;
     private int connectionTimeout;
     private boolean useSsl = false;
     private String cacheKey = null;
@@ -52,6 +58,8 @@ public class RedisServer {
     private java.util.Set<String> sentinels;
     private String masterPassword;
     private int dbNumber = DEFAULT_DATABASE;
+    private Lock lock = new ReentrantLock();
+    private Lock jedisLock = new ReentrantLock();
 
     public RedisServer(MessageContext messageContext) {
         this.messageContext = messageContext;
@@ -66,13 +74,28 @@ public class RedisServer {
         String sslProp = (String) messageContext.getProperty(RedisConstants.USESSL);
 
         String sentinelEnabled = (String) messageContext.getProperty(RedisConstants.SENTINEL_ENABLED);
+        String maxConnectionsProp = (String) messageContext.getProperty(RedisConstants.MAX_CONNECTIONS);
+
+        if (maxConnectionsProp != null && !maxConnectionsProp.isEmpty()) {
+            try {
+                maxConnections = Integer.parseInt(maxConnectionsProp);
+            } catch (NumberFormatException e) {
+                throw new SynapseException(
+                        "Invalid input for \"maxConnections\". Cannot parse " + maxConnectionsProp
+                                + " to an Integer.", e);
+            }
+        } else {
+            // setting 8 as the default value of maxConnections
+            maxConnections = RedisConstants.DEFAULT_MAX_CONNECTIONS;
+        }
+
         if (sentinelEnabled != null && !sentinelEnabled.isEmpty()) {
             isSentinelEnabled = Boolean.parseBoolean(sentinelEnabled);
         }
 
         if (soTimeoutProp != null && !soTimeoutProp.isEmpty()) {
             try {
-                timeout = Integer.parseInt(soTimeoutProp);
+                soTimeout = Integer.parseInt(soTimeoutProp);
             } catch (NumberFormatException e) {
                 throw new SynapseException(
                         "Invalid input for \"redisTimeout\". Cannot parse " + soTimeoutProp + " to an Integer.", e);
@@ -88,7 +111,7 @@ public class RedisServer {
             }
         } else {
             // setting socket timeout value as the default value of connection timeout
-            connectionTimeout = timeout;
+            connectionTimeout = soTimeout;
         }
 
         if (cacheKeyProp != null && !cacheKeyProp.isEmpty()) {
@@ -100,6 +123,21 @@ public class RedisServer {
         }
     }
 
+    private void buildJedisPool(String host, int port, int connectionTimeout, int soTimeout,
+                                boolean ssl) {
+        final JedisPoolConfig poolConfig = new JedisPoolConfig();
+        poolConfig.setMaxTotal(maxConnections); //The maximum number of connections that are supported by the pool.
+        poolConfig.setMaxIdle(maxConnections); // Is the actual maximum number of connections required by workloads
+        // (maxTotal = maxIdle)
+        poolConfig.setTestOnBorrow(false); //set to default false
+        poolConfig.setTestOnReturn(false); //set to default false
+        poolConfig.setTestWhileIdle(true);
+        poolConfig.setNumTestsPerEvictionRun(3);
+        poolConfig.setBlockWhenExhausted(true);
+        jedisPool = new JedisPool(poolConfig, host, port, connectionTimeout, soTimeout, null, dbNumber,
+                null, ssl);
+    }
+
     /**
      * Create a Jedis instance according to the parameters given.
      *
@@ -108,7 +146,6 @@ public class RedisServer {
     private Jedis createJedis() {
 
         if (isSentinelEnabled) {
-
             return createSentinel();
         }
         
@@ -117,7 +154,7 @@ public class RedisServer {
             try {
                 URI connectionURI = new URI(connectionURIProp);
                 JedisShardInfo shardInfo = new JedisShardInfo(connectionURI);
-                shardInfo.setSoTimeout(timeout);
+                shardInfo.setSoTimeout(soTimeout);
                 shardInfo.setConnectionTimeout(connectionTimeout);
                 return new Jedis(shardInfo);
             } catch (URISyntaxException e) {
@@ -153,11 +190,22 @@ public class RedisServer {
         }
 
         if (!Objects.isNull(cacheKey) && !cacheKey.isEmpty()) {
-            JedisShardInfo shardInfo = new JedisShardInfo(host, port, connectionTimeout, timeout, weight, useSsl);
+            JedisShardInfo shardInfo = new JedisShardInfo(host, port, connectionTimeout, soTimeout, weight, useSsl);
             shardInfo.setPassword(cacheKey);
             return new Jedis(shardInfo);
         }
-        return new Jedis(host, port, connectionTimeout, timeout, useSsl);
+        //Use double lock to avoid creating a new Jedis Sentinel connection pool for each request.
+        if (jedisPool == null) {
+            jedisLock.lock();
+            try {
+                if (jedisPool == null) {
+                    buildJedisPool(host, port, connectionTimeout, soTimeout, useSsl);
+                }
+            } finally {
+                jedisLock.unlock();
+            }
+        }
+        return jedisPool.getResource();
     }
 
     private Jedis createSentinel() {
@@ -168,7 +216,7 @@ public class RedisServer {
         } else{
             throw new SynapseException("Value for \"masterName\" cannot be empty in sentinel");
         }
-        
+
         String sentinelsProp = (String) messageContext.getProperty(RedisConstants.SENTINELS);
         if (sentinelsProp != null && !sentinelsProp.isEmpty()) {
             sentinels = new HashSet<>(Arrays.asList(sentinelsProp.split(",")));
@@ -186,16 +234,27 @@ public class RedisServer {
                         "Invalid input for \"dbNumber\". Cannot parse " + dbNumberProp + " to an Integer.", e);
             }
         }
-        
+
         String masterPasswordProp = (String) messageContext.getProperty(RedisConstants.MASTER_PASSWORD);
         if (masterPasswordProp != null && !masterPasswordProp.isEmpty()) {
             masterPassword = masterPasswordProp;
         }
-
-        try (JedisSentinelPool jedisSentinelPool = new JedisSentinelPool(masterName, sentinels,
-                new GenericObjectPoolConfig(), connectionTimeout, timeout, masterPassword, dbNumber)) {
-            return jedisSentinelPool.getResource();
+        //Use double lock to avoid creating a new Jedis Sentinel connection pool for each request.
+        if (jedisSentinelPool == null) {
+            lock.lock();
+            try {
+                if (jedisSentinelPool == null) {
+                    GenericObjectPoolConfig config = new GenericObjectPoolConfig();
+                    config.setMaxTotal(maxConnections);
+                    config.setMaxIdle(maxConnections);
+                    jedisSentinelPool = new JedisSentinelPool(masterName, sentinels, config, connectionTimeout,
+                            soTimeout, masterPassword, dbNumber);
+                }
+            } finally {
+                lock.unlock();
+            }
         }
+        return jedisSentinelPool.getResource();
     }
 
     /**
@@ -238,14 +297,13 @@ public class RedisServer {
             jedisClusterNodes.add(new HostAndPort(redisNode[0].trim(), Integer.parseInt(redisNode[1].trim())));
         }
 
-        return new JedisCluster(jedisClusterNodes, connectionTimeout, timeout, maxAttempts,
+        return new JedisCluster(jedisClusterNodes, connectionTimeout, soTimeout, maxAttempts,
                                 cacheKey, clientName, new GenericObjectPoolConfig(),
                                 useSsl);
     }
 
     public Jedis getJedis() {
-        this.jedis = createJedis();
-        return jedis;
+        return createJedis();
     }
 
     public JedisCluster getJedisCluster() {
@@ -257,9 +315,6 @@ public class RedisServer {
      * Close the datasources objects associated Jedis and JedisCluster instances.
      */
     public void close() {
-        if (jedis != null) {
-            jedis.close();
-        }
         if (jedisCluster != null) {
             jedisCluster.close();
         }

--- a/src/main/java/org/wso2/carbon/connector/operations/Rename.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Rename.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class Rename extends AbstractConnector {
 
@@ -37,7 +38,15 @@ public class Rename extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().rename(oldKey, newKey);
             } else {
-                response = serverObj.getJedis().rename(oldKey, newKey);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.rename(oldKey, newKey);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/RenamenX.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/RenamenX.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class RenamenX extends AbstractConnector {
 
@@ -37,7 +38,15 @@ public class RenamenX extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().renamenx(oldKey, newKey);
             } else {
-                response = serverObj.getJedis().renamenx(oldKey, newKey);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.renamenx(oldKey, newKey);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/SDiffStore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SDiffStore.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class SDiffStore extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class SDiffStore extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().sdiffstore(dstKey, keyValue);
             } else {
-                response = serverObj.getJedis().sdiffstore(dstKey, keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.sdiffstore(dstKey, keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/SInter.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SInter.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -39,7 +40,16 @@ public class SInter extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().sinter(keyValue);
             } else {
-                response = serverObj.getJedis().sinter(keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.sinter(keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
+
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response.toString());

--- a/src/main/java/org/wso2/carbon/connector/operations/SInterStore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SInterStore.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class SInterStore extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class SInterStore extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().sinterstore(dstKey, keyValue);
             } else {
-                response = serverObj.getJedis().sinterstore(dstKey, keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.sinterstore(dstKey, keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/SIsMember.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SIsMember.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class SIsMember extends AbstractConnector {
 
@@ -37,7 +38,15 @@ public class SIsMember extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().sismember(key, member);
             } else {
-                response = serverObj.getJedis().sismember(key, member);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.sismember(key, member);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/SMembers.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SMembers.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -38,7 +39,15 @@ public class SMembers extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().smembers(key);
             } else {
-                response = serverObj.getJedis().smembers(key);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.smembers(key);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response.toString());

--- a/src/main/java/org/wso2/carbon/connector/operations/SMove.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SMove.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class SMove extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class SMove extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().smove(srcKey, dstKey, member);
             } else {
-                response = serverObj.getJedis().smove(srcKey, dstKey, member);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.smove(srcKey, dstKey, member);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/SPop.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SPop.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class SPop extends AbstractConnector {
 
@@ -36,7 +37,15 @@ public class SPop extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().spop(key);
             } else {
-                response = serverObj.getJedis().spop(key);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.spop(key);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/SRandMember.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SRandMember.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class SRandMember extends AbstractConnector {
 
@@ -36,7 +37,15 @@ public class SRandMember extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().srandmember(key);
             } else {
-                response = serverObj.getJedis().srandmember(key);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.srandmember(key);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/SRem.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SRem.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class SRem extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class SRem extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().srem(key, keyValue);
             } else {
-                response = serverObj.getJedis().srem(key, keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.srem(key, keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/SUnion.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SUnion.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -39,7 +40,15 @@ public class SUnion extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().sunion(keyValue);
             } else {
-                response = serverObj.getJedis().sunion(keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.sunion(keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response.toString());

--- a/src/main/java/org/wso2/carbon/connector/operations/SUnionStore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SUnionStore.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class SUnionStore extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class SUnionStore extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().sunionstore(dstKey, keyValue);
             } else {
-                response = serverObj.getJedis().sunionstore(dstKey, keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.sunionstore(dstKey, keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/Sadd.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Sadd.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class Sadd extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class Sadd extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().sadd(key, keyValue);
             } else {
-                response = serverObj.getJedis().sadd(key, keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.sadd(key, keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/Set.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Set.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class Set extends AbstractConnector {
 
@@ -37,7 +38,15 @@ public class Set extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().set(key, value);
             } else {
-                response = serverObj.getJedis().set(key, value);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.set(key, value);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/SetBit.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SetBit.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class SetBit extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class SetBit extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().setbit(key, offset, value);
             } else {
-                response = serverObj.getJedis().setbit(key, offset, value);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.setbit(key, offset, value);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/SetRange.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SetRange.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class SetRange extends AbstractConnector {
 
@@ -38,7 +39,16 @@ public class SetRange extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().setrange(key, offset, value);
             } else {
-                response = serverObj.getJedis().setrange(key, offset, value);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.setrange(key, offset, value);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
+
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/SetnX.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/SetnX.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class SetnX extends AbstractConnector {
 
@@ -37,7 +38,15 @@ public class SetnX extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().setnx(key, value);
             } else {
-                response = serverObj.getJedis().setnx(key, value);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.setnx(key, value);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/StrLen.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/StrLen.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class StrLen extends AbstractConnector {
 
@@ -36,7 +37,15 @@ public class StrLen extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().strlen(key);
             } else {
-                response = serverObj.getJedis().strlen(key);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.strlen(key);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/Ttl.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Ttl.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class Ttl extends AbstractConnector {
 
@@ -36,7 +37,15 @@ public class Ttl extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().ttl(key);
             } else {
-                response = serverObj.getJedis().ttl(key);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.ttl(key);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/Type.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Type.java
@@ -37,7 +37,16 @@ public class Type extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().type(key);
             } else {
-                response = serverObj.getJedis().type(key);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.type(key);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
+
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/ZCount.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZCount.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class ZCount extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class ZCount extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().zcount(key, min, max);
             } else {
-                response = serverObj.getJedis().zcount(key, min, max);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.zcount(key, min, max);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/ZIncrBy.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZIncrBy.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class ZIncrBy extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class ZIncrBy extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().zincrby(key, score, member);
             } else {
-                response = serverObj.getJedis().zincrby(key, score, member);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.zincrby(key, score, member);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/ZInterStore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZInterStore.java
@@ -23,6 +23,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class ZInterStore extends AbstractConnector {
 
@@ -39,7 +40,16 @@ public class ZInterStore extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().zinterstore(dstKey, keyValue);
             } else {
-                response = serverObj.getJedis().zinterstore(dstKey, keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.zinterstore(dstKey, keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
+
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRange.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRange.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -40,7 +41,15 @@ public class ZRange extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().zrange(key, start, end);
             } else {
-                response = serverObj.getJedis().zrange(key, start, end);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.zrange(key, start, end);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response.toString());

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRangeByScore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRangeByScore.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -40,7 +41,15 @@ public class ZRangeByScore extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().zrangeByScore(key, min, max);
             } else {
-                response = serverObj.getJedis().zrangeByScore(key, min, max);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.zrangeByScore(key, min, max);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response.toString());

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRank.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRank.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class ZRank extends AbstractConnector {
 
@@ -37,7 +38,16 @@ public class ZRank extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().zrank(key, member);
             } else {
-                response = serverObj.getJedis().zrank(key, member);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.zrank(key, member);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
+
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRem.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRem.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class ZRem extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class ZRem extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().zrem(key, keyValue);
             } else {
-                response = serverObj.getJedis().zrem(key, keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.zrem(key, keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRemRangeByRank.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRemRangeByRank.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class ZRemRangeByRank extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class ZRemRangeByRank extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().zremrangeByRank(key, start, end);
             } else {
-                response = serverObj.getJedis().zremrangeByRank(key, start, end);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.zremrangeByRank(key, start, end);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRemRangeByScore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRemRangeByScore.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class ZRemRangeByScore extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class ZRemRangeByScore extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().zremrangeByScore(key, start, end);
             } else {
-                response = serverObj.getJedis().zremrangeByScore(key, start, end);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.zremrangeByScore(key, start, end);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRevRange.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRevRange.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -40,7 +41,15 @@ public class ZRevRange extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().zrevrange(key, start, end);
             } else {
-                response = serverObj.getJedis().zrevrange(key, start, end);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.zrevrange(key, start, end);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response.toString());

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRevRangeByScore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRevRangeByScore.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 import java.util.Set;
 
@@ -40,7 +41,15 @@ public class ZRevRangeByScore extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().zrevrangeByScore(key, min, max);
             } else {
-                response = serverObj.getJedis().zrevrangeByScore(key, min, max);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.zrevrangeByScore(key, min, max);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response.toString());

--- a/src/main/java/org/wso2/carbon/connector/operations/ZRevRank.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZRevRank.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class ZRevRank extends AbstractConnector {
 
@@ -37,7 +38,15 @@ public class ZRevRank extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().zrevrank(key, member);
             } else {
-                response = serverObj.getJedis().zrevrank(key, member);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.zrevrank(key, member);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/ZScore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZScore.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class ZScore extends AbstractConnector {
 
@@ -37,7 +38,15 @@ public class ZScore extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().zscore(key, member);
             } else {
-                response = serverObj.getJedis().zscore(key, member);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.zscore(key, member);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/ZUnionStore.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/ZUnionStore.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class ZUnionStore extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class ZUnionStore extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().zunionstore(dstKey, keyValue);
             } else {
-                response = serverObj.getJedis().zunionstore(dstKey, keyValue);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.zunionstore(dstKey, keyValue);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/operations/Zadd.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Zadd.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import redis.clients.jedis.Jedis;
 
 public class Zadd extends AbstractConnector {
 
@@ -38,7 +39,15 @@ public class Zadd extends AbstractConnector {
             if (serverObj.isClusterEnabled()) {
                 response = serverObj.getJedisCluster().zadd(key, score, member);
             } else {
-                response = serverObj.getJedis().zadd(key, score, member);
+                Jedis jedis = null;
+                try {
+                    jedis = serverObj.getJedis();
+                    response = jedis.zadd(key, score, member);
+                } finally {
+                    if (jedis != null) {
+                        jedis.close();
+                    }
+                }
             }
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);

--- a/src/main/java/org/wso2/carbon/connector/util/RedisConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/util/RedisConstants.java
@@ -67,10 +67,14 @@ public class RedisConstants {
     public static final String MAX_ATTEMPTS = "maxAttempts";
     public static final String WEIGHT = "weight";
     public static final String MAX_CONNECTIONS = "maxConnections";
+    public static final String CONNECTION_POOL_ID = "redisConnectionPoolId";
+    public static final String INTERNAL_POOL_ID_SEPARATOR = "INTERNAL_POOL_ID_";
+    public static final String ARTIFACT_NAME = "ARTIFACT_NAME";
 
     public static final int DEFAULT_TIMEOUT = 2000;
     public static final int DEFAULT_MAX_ATTEMPTS = 5;
     public static final int DEFAULT_MAX_CONNECTIONS = 8;
+    public static final String DEFAULT_CONNECTION_POOL_ID = "0";
     public static final int DEFAULT_WEIGHT = 1;
     
      public static final String SENTINEL_ENABLED = "sentinelEnabled";

--- a/src/main/java/org/wso2/carbon/connector/util/RedisConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/util/RedisConstants.java
@@ -66,9 +66,11 @@ public class RedisConstants {
     public static final String CLIENT_NAME = "clientName";
     public static final String MAX_ATTEMPTS = "maxAttempts";
     public static final String WEIGHT = "weight";
+    public static final String MAX_CONNECTIONS = "maxConnections";
 
     public static final int DEFAULT_TIMEOUT = 2000;
     public static final int DEFAULT_MAX_ATTEMPTS = 5;
+    public static final int DEFAULT_MAX_CONNECTIONS = 8;
     public static final int DEFAULT_WEIGHT = 1;
     
      public static final String SENTINEL_ENABLED = "sentinelEnabled";

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -24,6 +24,7 @@
     <parameter name="useSsl" description="a flag to switch between SSL and non-SSL"/>
     <parameter name="maxConnections"
                description="The maximum number of connections that are supported by the jedis pool"/>
+    <parameter name="redisConnectionPoolId" description="the connection pool id for create unique pool"/>
 
     <!-- standalone mode specific parameters-->
     <parameter name="redisHost" description="the server host"/>
@@ -49,6 +50,12 @@
             <then/>
             <else>
                 <property name="redisPort" expression="$func:redisPort"/>
+            </else>
+        </filter>
+        <filter xpath="$func:redisConnectionPoolId = '' or  not(string($func:redisConnectionPoolId))">
+            <then/>
+            <else>
+                <property name="redisConnectionPoolId" expression="$func:redisConnectionPoolId"/>
             </else>
         </filter>
         <filter xpath="$func:redisTimeout = '' or  not(string($func:redisTimeout))">

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -22,6 +22,8 @@
     <parameter name="redisTimeout" description="time to live the server in milliseconds"/>
     <parameter name="cacheKey" description="key of the cache"/>
     <parameter name="useSsl" description="a flag to switch between SSL and non-SSL"/>
+    <parameter name="maxConnections"
+               description="The maximum number of connections that are supported by the jedis pool"/>
 
     <!-- standalone mode specific parameters-->
     <parameter name="redisHost" description="the server host"/>
@@ -101,6 +103,12 @@
             <then/>
             <else>
                 <property name="maxAttempts" expression="$func:maxAttempts"/>
+            </else>
+        </filter>
+        <filter xpath="$func:maxConnections = '' or  not(string($func:maxConnections))">
+            <then/>
+            <else>
+                <property name="maxConnections" expression="$func:maxConnections"/>
             </else>
         </filter>
         <filter xpath="$func:weight = '' or  not(string($func:weight))">


### PR DESCRIPTION
## Purpose
Fix creating connections for each request in the Redis connector by introducing a connection pool and double lock.
    
    
## Goals
Fixes: https://github.com/wso2/micro-integrator/issues/2685


## Approach
Fix creating connections for each request by introducing a connection pool and double lock. Also had to Restructure operations to release connections to the pool. Also defined separate pools for each connector instance

Now users can define The maximum number of connections that are supported by the pool (which should be less than the max client connection limit of Redis)
by using <maxConnections> property in the <redis.init> section. If the max client connection limit of Redis is 5 we can set this to 3.

```
<redis.init>
                <redisHost>localhost</redisHost>
                <redisPort>6379</redisPort>
                <maxConnections>3</maxConnections>
</redis.init>
```
Also internally we are keeping separate pools for each artifact by using ARTIFACT_NAME as a unique name. If and only if user wants to add 2 or more connectors to a single artifact (say one API) then the user has to differentiate the Redis connectors within that artifact with <redisConnectionPoolId> param.

```
<redis.init>
                <redisConnectionPoolId>1</redisConnectionPoolId>
                <redisHost>localhost</redisHost>
                <redisPort>6379</redisPort>
                <maxConnections>3</maxConnections>
</redis.init>
```
