### PR TITLE
Add proper pooling support for JedisCluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.redis</artifactId>
     <packaging>jar</packaging>
-    <version>2.6.0</version>
+    <version>2.7.0</version>
     <name>WSO2 Carbon - Mediation Library Connector For Redis</name>
     <url>http://wso2.org</url>
     <properties>

--- a/src/main/java/org/wso2/carbon/connector/util/RedisConstants.java
+++ b/src/main/java/org/wso2/carbon/connector/util/RedisConstants.java
@@ -74,6 +74,7 @@ public class RedisConstants {
     public static final String MAX_ATTEMPTS = "maxAttempts";
     public static final String WEIGHT = "weight";
     public static final String MAX_CONNECTIONS = "maxConnections";
+    public static final String IS_JMX_ENABLED = "jmxEnabled";
     public static final String CONNECTION_POOL_ID = "redisConnectionPoolId";
     public static final String INTERNAL_POOL_ID_SEPARATOR = "INTERNAL_POOL_ID_";
     public static final String ARTIFACT_NAME = "ARTIFACT_NAME";

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -37,7 +37,8 @@
     <parameter name="clusterNodes" description="comma separated list of the cluster nodes (host:port)"/>
     <parameter name="clientName" description="name of the client"/>
     <parameter name="maxAttempts" description="the number of retries"/>
-    
+    <parameter name="jmxEnabled" description="a flag to enable jmx"/>
+
     <!-- Redis Sentinel specific parameters-->
     <parameter name="sentinelPassword" description="sentinel password"/>
     <parameter name="sentinelUser" description="sentinel user name"/>
@@ -98,6 +99,12 @@
             <then/>
             <else>
                 <property name="redisClusterEnabled" expression="$func:redisClusterEnabled"/>
+            </else>
+        </filter>
+        <filter xpath="$func:jmxEnabled = '' or  not(string($func:jmxEnabled))">
+            <then/>
+            <else>
+                <property name="jmxEnabled" expression="$func:jmxEnabled"/>
             </else>
         </filter>
         <filter xpath="$func:clusterNodes = '' or  not(string($func:clusterNodes))">


### PR DESCRIPTION


## Purpose
Previously we were creating a single pool for each cluster operation. This Pr rectifies that and also avoids closing JedisCluster after each operation since It's no need to close the JedisCluster instance as it is handled by the JedisClusterConnectionPool itself.
Also introduced the "isJmxEnabled" property to enable JMX if required.

Fixes: https://github.com/wso2/api-manager/issues/1690