### PR TITLE
Send empty string when redis cache for the key is null

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/operations/Get.java
+++ b/src/main/java/org/wso2/carbon/connector/operations/Get.java
@@ -22,6 +22,7 @@ import org.apache.synapse.MessageContext;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.util.RedisConstants;
+import org.wso2.carbon.connector.util.Constants;
 import redis.clients.jedis.Jedis;
 
 public class Get extends AbstractConnector {
@@ -50,7 +51,7 @@ public class Get extends AbstractConnector {
             if (response != null) {
                 messageContext.setProperty(RedisConstants.RESULT, response);
             } else {
-                handleException("Redis server throw null response", messageContext);
+                response = Constants.NULL_STRING;
             }
         } catch (Exception e) {
             handleException("Error while connecting the server or calling the redis method", e, messageContext);


### PR DESCRIPTION
Throwing exceptions causes the runtime to fail when the Redis cache is not available for a given key. If the Redis key is empty redis response should be an empty string. This is the behaviour of Redis HGet operation
